### PR TITLE
compile without cegui

### DIFF
--- a/archlinux/dev/fife-git/PKGBUILD
+++ b/archlinux/dev/fife-git/PKGBUILD
@@ -26,7 +26,7 @@ build() {
   # [TODO] Due to severe laziness, I have not tested in-source builds yet
   [[ -d "build" ]] && rm -r "build"
   mkdir -p "build" && cd "build"
-  cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
+  cmake -Dcegui=OFF -DCMAKE_INSTALL_PREFIX:PATH=/usr ..
   # to build C/C++ version comment this in and the line above out.
   # cmake -Dbuild-library=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_LIBDIR:PATH=/usr/lib ..
   make


### PR DESCRIPTION
Without this flag fife will require cegui.
Since cegui is not mentioned as dependency and cegui has problems compiling on archlinux in the first place it's better not to use cegui